### PR TITLE
Display logs of a container

### DIFF
--- a/electron_src/controllers/container-logs.js
+++ b/electron_src/controllers/container-logs.js
@@ -1,0 +1,14 @@
+const cmdLikeAPro = require('../utilities/cmd-pro')
+
+module.exports = getContainerLogs = containerID => new Promise( 
+  async (resolve, reject) => {
+    try {
+      const cmd = `docker container logs ${containerID} --tail 1500`
+      const data = await cmdLikeAPro(cmd)
+      resolve({logs: data})
+    } catch (error) {
+      reject(error)
+      console.log('Error in container-logs.js', error)
+    }
+  }
+ )

--- a/electron_src/controllers/nodeLogs.js
+++ b/electron_src/controllers/nodeLogs.js
@@ -1,7 +1,0 @@
-const cmdLikeAPro = require('../utilities/cmd-pro')
-
-module.exports = getContainerLogs = containerID => new Promise( async (resolve, reject) => {
-  const cmd = `docker container logs ${containerID}`
-  const data = await cmdLikeAPro(cmd)
-  resolve(data)
-})

--- a/electron_src/utilities/cmd-pro.js
+++ b/electron_src/utilities/cmd-pro.js
@@ -1,8 +1,8 @@
-const cmd = require('node-cmd')
+const child_process = require( 'child_process' )
 
 module.exports = cmdLikeAPro = command => new Promise((resolve, reject) => {
-  cmd.get(command, (err, data, stderr) => {
-    if(err || stderr) reject(err || stderr)
-    else resolve(data)
+  child_process.exec(command, {maxBuffer : 1500 * 1024}, function(error, stdout, stderr) {
+    if( !!error ) reject( error )
+    else resolve( stdout || stderr )
   })
 })

--- a/electron_src/utilities/communicator.js
+++ b/electron_src/utilities/communicator.js
@@ -2,7 +2,7 @@ const { ipcMain } = require('electron')
 const containerController = require('../controllers/containers/fetch-containers')
 const fetchContainerStats = require('../controllers/containers/fetch-stats')
 const containerCmdActions = require('../controllers/containers/container-cmd-actions')
-const nodeLogs            = require('../controllers/nodeLogs')
+const containerLogs = require('../controllers/container-logs')
 
 module.exports = communicator = async () => {
 
@@ -38,15 +38,18 @@ module.exports = communicator = async () => {
 
   ipcMain.on('get-single-container-message', async (event, arg) => {
     const payloads = JSON.parse(arg)
-    const container = await containerController.fetchContainerByID(payloads.options)
-    event.sender.send('get-single-container', JSON.stringify(container))
+    try {
+      const container = await containerController.fetchContainerByID(payloads.options)
+      event.sender.send('get-single-container', JSON.stringify(container))
+    } catch (error) {
+      console.log(error)
+    }
   })
 
   ipcMain.on('get-container-logs-message', async (event, arg) => {
-    const payloads    = JSON.parse(arg)
-    const logs        = await nodeLogs.getContainerLogs(payloads.nodeID)
-    event.sender.send('get-single-container', logs)
+    const payloads = JSON.parse(arg)
+    const logs = await containerLogs(payloads.options.nodeID)
+    event.sender.send('get-container-logs', JSON.stringify(logs))
   })
-
 
 }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,6 @@
     "electron": "^3.0.5",
     "evergreen-ui": "^4.0.2",
     "javascript-time-ago": "^1.0.31",
-    "node-cmd": "^3.0.0",
     "react": "^16.5.2",
     "react-dom": "^16.5.2",
     "react-redux": "^5.0.7",

--- a/src/actions/nodesLog.js
+++ b/src/actions/nodesLog.js
@@ -1,10 +1,7 @@
-export const openLogExplorer = payload => {
-  // console.log('From action:', payload)
-  return {
-    type: 'OPEN_LOG_EXPLORER',
-    payload,
-  }
-}
+export const openLogExplorer = payload => ({
+  type: 'OPEN_LOG_EXPLORER',
+  payload,
+})
 
 export const closeLogExplorer = payload => ({
   type: 'CLOSE_LOG_EXPLORER'

--- a/src/components/ContainerActions/ContainerActions.js
+++ b/src/components/ContainerActions/ContainerActions.js
@@ -1,5 +1,4 @@
 import React, { Component } from 'react'
-import { Pill } from 'evergreen-ui'
 import { connect } from 'react-redux'
 
 class ContainerLiveStats extends Component {
@@ -10,7 +9,7 @@ class ContainerLiveStats extends Component {
     const validStat = stat[0] ? stat[0] : false
 
     if(!validStat) return null
-    // console.log(validStat)
+    
     return <div>hello</div>
   }
 }

--- a/src/components/ContainerLiveStats/ContainerLiveStats.js
+++ b/src/components/ContainerLiveStats/ContainerLiveStats.js
@@ -16,7 +16,7 @@ class ContainerLiveStats extends Component {
     const validStat = stat[0] ? stat[0] : false
 
     if(!validStat) return null
-    // console.log(validStat)
+    
     return <>
       <Pill 
         paddingLeft={10} 

--- a/src/components/ScreenNavigator.js
+++ b/src/components/ScreenNavigator.js
@@ -6,17 +6,27 @@ import {setScreen} from '../actions/screen'
 
 class ScreenNavigator extends Component {
 
-  render() {
+  navButton (name, amount, icon) {
+    return <Text display='flex' alignItems='center'>
+      <Icon size={14} color="muted" icon={ icon } marginRight={5}/> 
+        { name } 
+        <Badge color="neutral" marginLeft={5}>
+          { amount }
+        </Badge>
+    </Text>
+  }
+
+  render () {
     const {screen, setScreen} = this.props
     return <SegmentedControl
       width={750}
       height={50}
       options={[
-        { label: <Text display='flex' alignItems='center'><Icon size={14} color="muted" icon="layers" marginRight={5}/> Container <Badge color="neutral" marginLeft={5}>29</Badge></Text>, value: 'container' },
-        { label: <Text display='flex' alignItems='center'><Icon size={14} color="muted" icon="projects" marginRight={5}/> Image <Badge color="neutral" marginLeft={5}>8</Badge></Text>, value: 'image' },
-        { label: <Text display='flex' alignItems='center'><Icon size={14} color="muted" icon="database" marginRight={5}/> Volume <Badge color="neutral" marginLeft={5}>9</Badge></Text>, value: 'volume' },
-        { label: <Text display='flex' alignItems='center'><Icon size={14} color="muted" icon="cell-tower" marginRight={5}/> Network <Badge color="neutral" marginLeft={5}>4</Badge></Text>, value: 'network' },
-        { label: <Text display='flex' alignItems='center'><Icon size={14} color="muted" icon="shield" marginRight={5}/> Clean-up</Text>, value: 'cleanup' },
+        { label: this.navButton( 'Container', 29, 'layers' ), value: 'container' },
+        { label: this.navButton( 'Image', 8, 'projects' ), value: 'image' },
+        { label: this.navButton( 'Volume', 8, 'database' ), value: 'volume' },
+        { label: this.navButton( 'Network', 8, 'cell-tower' ), value: 'network' },
+        { label: this.navButton( 'Clean-up', 8, 'shield' ), value: 'cleanup' }
       ]}
       value={screen}
       onChange={value => setScreen(value)}

--- a/src/screens/CleanUpScreen.js
+++ b/src/screens/CleanUpScreen.js
@@ -4,8 +4,8 @@ class CleanUpScreen extends Component {
   render() {
     return <div style={{display: 'flex', flexDirection: 'column', justifyContent: 'center', alignItems: 'center'}}>
       {/* <iframe src="https://giphy.com/embed/6heBQSjt2IoA8" width="480" height="241" frameBorder="0" class="giphy-embed" allowFullScreen></iframe> */}
-      <h1>🦄</h1>
-      <div>This screen is not ready yet! I'm working hard in my weekends 🤞</div>
+      <h1><span>🦄</span></h1>
+      <div>This screen is not ready yet! I'm working hard in my weekends <span>🤞</span></div>
       <div>If you want to work on this screen and need help DM me in twitter @rakibtg</div>
     </div>
   }

--- a/src/screens/ContainerScreen.js
+++ b/src/screens/ContainerScreen.js
@@ -2,13 +2,14 @@ import React, { Component } from 'react'
 import './css/ContainerScreen.css'
 import fetcher from '../utils/fetcher'
 import { connect } from 'react-redux'
-import { Switch, Strong, Pill, Button, Pane,
-  Popover, Menu, toaster, Position, IconButton, Spinner } from 'evergreen-ui'
+import { Switch, Strong, Pill, Button, 
+  Pane, Popover, Menu, toaster, Position, 
+  IconButton, Spinner } from 'evergreen-ui'
 import ContainerIdPill from '../components/ContainerIdPill'
 import TimeAgo from 'javascript-time-ago'
 import en from 'javascript-time-ago/locale/en'
 import ContainerLiveStats from '../components/ContainerLiveStats/ContainerLiveStats'
-import {bindActionCreators} from 'redux'
+import { bindActionCreators } from 'redux'
 import { 
   setContainerInProgress,
   setContainerState
@@ -68,28 +69,31 @@ class ContainerScreen extends Component {
     return <Pane 
       display='flex'
       marginTop={12}>
-      <Button 
-        height={20} 
-        marginRight={5} 
-        iconBefore="refresh"
-        onClick={() => {
-          fetcher(
-            'containerCmdAction', 
-            {
-              containerID: container.shortId, 
-              cmdCommand: 'restart'
-            }
-          )
-          setContainerState({
-            containerID: container.shortId,
-            updatable: { 
-              Running: false,
-              Restarting: true,
-            }
-          })
-        }}>
-        Restart
-      </Button>
+      {
+        container.State.Running && 
+        <Button 
+          height={20} 
+          marginRight={5} 
+          iconBefore="refresh"
+          onClick={() => {
+            fetcher(
+              'containerCmdAction', 
+              {
+                containerID: container.shortId, 
+                cmdCommand: 'restart'
+              }
+            )
+            setContainerState({
+              containerID: container.shortId,
+              updatable: { 
+                Running: false,
+                Restarting: true,
+              }
+            })
+          }}>
+          Restart
+        </Button>
+      }
       <Button 
         height={20} 
         marginRight={5} 
@@ -144,83 +148,86 @@ class ContainerScreen extends Component {
         }}>
         Remove
       </Button>
-      <Popover
-        position={Position.BOTTOM_LEFT}
-        content={
-          <Menu>
-            <Menu.Group>
-              <Menu.Item
-                onSelect={
-                  () => fetcher('openLogViewer', {
-                    title: 'Container Logs',
-                    nodeID: container.shortId,
-                    data: 'Hello mellos',
-                    other: {}
-                  })
-                }
-                icon='clipboard'
-                height={20}
-                paddingTop={14}
-                paddingBottom={14}
-              >
-                Logs
-              </Menu.Item>
-              <Menu.Item
-                onSelect={() => toaster.notify('Share')}
-                icon='info-sign'
-                height={20}
-                paddingTop={14}
-                paddingBottom={14}
-              >
-                Info
-              </Menu.Item>
-              <Menu.Item
-                onSelect={() => toaster.notify('Share')}
-                icon='pause'
-                height={20}
-                paddingTop={14}
-                paddingBottom={14}
-              >
-                Pause all processes
-              </Menu.Item>
-              <Menu.Item
-                onSelect={() => toaster.notify('Move')}
-                icon='ban-circle'
-                height={20}
-                paddingTop={14}
-                paddingBottom={14}
-              >
-                Kill
-              </Menu.Item>
-              <Menu.Item
-                onSelect={() => toaster.notify('Rename')}
-                icon='edit'
-                height={20}
-                paddingTop={14}
-                paddingBottom={14}
-              >
-                Rename
-              </Menu.Item>
-              <Menu.Item
-                onSelect={() => toaster.notify('Rename')}
-                icon='cell-tower'
-                height={20}
-                paddingTop={14}
-                paddingBottom={14}
-              >
-                Port
-              </Menu.Item>
-            </Menu.Group>
-          </Menu>
-        }
-      >
-        <IconButton 
-          height={20} 
-          icon='cog'
-          width={40}
-          marginLeft={5}
-        />
-      </Popover>
+      {
+        container.State.Running && 
+          <Popover
+            position={Position.BOTTOM_LEFT}
+            content={
+              <Menu>
+                <Menu.Group>
+                  <Menu.Item
+                    onSelect={
+                      () => fetcher('openLogViewer', {
+                        title: 'Container Logs',
+                        nodeID: container.shortId,
+                        data: 'Hello mellos',
+                        other: {}
+                      })
+                    }
+                    icon='clipboard'
+                    height={20}
+                    paddingTop={14}
+                    paddingBottom={14}
+                  >
+                    Logs
+                  </Menu.Item>
+                  <Menu.Item
+                    onSelect={() => toaster.notify('Share')}
+                    icon='info-sign'
+                    height={20}
+                    paddingTop={14}
+                    paddingBottom={14}
+                  >
+                    Info
+                  </Menu.Item>
+                  <Menu.Item
+                    onSelect={() => toaster.notify('Share')}
+                    icon='pause'
+                    height={20}
+                    paddingTop={14}
+                    paddingBottom={14}
+                  >
+                    Pause all processes
+                  </Menu.Item>
+                  <Menu.Item
+                    onSelect={() => toaster.notify('Move')}
+                    icon='ban-circle'
+                    height={20}
+                    paddingTop={14}
+                    paddingBottom={14}
+                  >
+                    Kill
+                  </Menu.Item>
+                  <Menu.Item
+                    onSelect={() => toaster.notify('Rename')}
+                    icon='edit'
+                    height={20}
+                    paddingTop={14}
+                    paddingBottom={14}
+                  >
+                    Rename
+                  </Menu.Item>
+                  <Menu.Item
+                    onSelect={() => toaster.notify('Rename')}
+                    icon='cell-tower'
+                    height={20}
+                    paddingTop={14}
+                    paddingBottom={14}
+                  >
+                    Port
+                  </Menu.Item>
+                </Menu.Group>
+              </Menu>
+            }
+          >
+            <IconButton 
+              height={20} 
+              icon='cog'
+              width={40}
+              marginLeft={5}
+            />
+          </Popover>
+      }
     </Pane>
   }
 

--- a/src/screens/ImageScreen.js
+++ b/src/screens/ImageScreen.js
@@ -4,8 +4,8 @@ class ImageScreen extends Component {
   render() {
     return <div style={{display: 'flex', flexDirection: 'column', justifyContent: 'center', alignItems: 'center'}}>
       {/* <iframe src="https://giphy.com/embed/6heBQSjt2IoA8" width="480" height="241" frameBorder="0" class="giphy-embed" allowFullScreen></iframe> */}
-      <h1>🦄</h1>
-      <div>This screen is not ready yet! I'm working hard in my weekends 🤞</div>
+      <h1><span>🦄</span></h1>
+      <div>This screen is not ready yet! I'm working hard in my weekends <span>🤞</span></div>
       <div>If you want to work on this screen and need help DM me in twitter @rakibtg</div>
     </div>
   }

--- a/src/screens/NetworkScreen.js
+++ b/src/screens/NetworkScreen.js
@@ -4,8 +4,8 @@ class NewtowrkScreen extends Component {
   render() {
     return <div style={{display: 'flex', flexDirection: 'column', justifyContent: 'center', alignItems: 'center'}}>
       {/* <iframe src="https://giphy.com/embed/6heBQSjt2IoA8" width="480" height="241" frameBorder="0" class="giphy-embed" allowFullScreen></iframe> */}
-      <h1>🦄</h1>
-      <div>This screen is not ready yet! I'm working hard in my weekends 🤞</div>
+      <h1><span>🦄</span></h1>
+      <div>This screen is not ready yet! I'm working hard in my weekends <span>🤞</span></div>
       <div>If you want to work on this screen and need help DM me in twitter @rakibtg</div>
     </div>
   }

--- a/src/screens/VolumeScreen.js
+++ b/src/screens/VolumeScreen.js
@@ -4,8 +4,8 @@ class VolumeScreen extends Component {
   render() {
     return <div style={{display: 'flex', flexDirection: 'column', justifyContent: 'center', alignItems: 'center'}}>
       {/* <iframe src="https://giphy.com/embed/6heBQSjt2IoA8" width="480" height="241" frameBorder="0" class="giphy-embed" allowFullScreen></iframe> */}
-      <h1>🦄</h1>
-      <div>This screen is not ready yet! I'm working hard in my weekends 🤞</div>
+      <h1><span>🦄</span></h1>
+      <div>This screen is not ready yet! I'm working hard in my weekends <span>🤞</span></div>
       <div>If you want to work on this screen and need help DM me in twitter @rakibtg</div>
     </div>
   }

--- a/src/utils/fetcher.js
+++ b/src/utils/fetcher.js
@@ -67,7 +67,7 @@ const recipes = {
         recipes.removeContainerFromStore(payload.containerID)
       }
     } catch (error) {
-      // I think this block will never gets executed as from the electron event we never received an error response.
+      console.log('Fetcher.js Error - 9378', error)
     }
     resolve(true)
   }),
@@ -78,10 +78,19 @@ const recipes = {
   removeContainerFromStore: containerID => {
     store.dispatch(removeContainerFromStoreByID(containerID))
   },
-  openLogViewer: async data => {
-    const logs = await reactToElectron('get-container-logs', data)
-    store.dispatch(openLogExplorer(data))
+  openLogViewer: async ({title, nodeID, data = 'No logs are found!', other}) => {
+    try {
+      data = await reactToElectron('get-container-logs', { nodeID })
+    } catch (error) {
+      console.log('Fetcher.js Error - 2626', error)
+    }
+    store.dispatch(openLogExplorer({
+      title,
+      nodeID,
+      data: data.logs,
+      other
+    }))
   }
 }
 
-export default async (recipe, options = {}) => recipes[ recipe ](options)
+export default async (recipe, options = {}) => recipes[ recipe ]( options )

--- a/src/utils/reactToElectron.js
+++ b/src/utils/reactToElectron.js
@@ -1,4 +1,4 @@
-const {ipcRenderer} = window.require('electron')
+const { ipcRenderer } = window.require('electron')
 
 export default (type, options) => new Promise((resolve, reject) => {
   ipcRenderer.send(type+'-message', JSON.stringify({ type, options }))
@@ -7,6 +7,7 @@ export default (type, options) => new Promise((resolve, reject) => {
       const data = JSON.parse(arg)
       resolve(data)
     } catch (error) {
+      console.log('reactToElectron.js Error: ', error)
       reject('Failed')
     }
   })


### PR DESCRIPTION
This PR will let you view logs of a container in the app. From the action dropdown of a container list click on the settings icon and then on the Logs menu in order to view the log report.

<img width="843" alt="Screen Shot 2019-03-30 at 5 29 20 PM" src="https://user-images.githubusercontent.com/5412730/55275507-5eb54c00-5311-11e9-9509-4434b726fa15.png">

<img width="1112" alt="Screen Shot 2019-03-30 at 5 29 59 PM" src="https://user-images.githubusercontent.com/5412730/55275510-755ba300-5311-11e9-98b5-f12065c47c0d.png">

Some containers logs will be huge enough to cause buffer memory limit error, so I have added max 1500 tail to log data for a container.

We also getting opted the third party "node-cmd" plugin in favor of the `exec` from `child_process`, because "node-cmd" module has no API to set the max buffer limit.

It also contains socket type fix for container logs, and some other refactoring, and code cleanups.